### PR TITLE
housekeeping: fixup minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ changes to the device zones condition, attributes and state (such as a
 sequential zone write pointer location). These changes are not internally
 tracked by *libzbc*. The functions provided to obtain the device zone
 information only provide a snapshot of the zone condition and state when
-executed. It is the responsability of an application to implement tracking of
+executed. It is the responsibility of an application to implement tracking of
 the device zone changes (such as increment to a sequential zone write pointer as
 writes to the zone are executed) if necessary.
 
@@ -260,7 +260,7 @@ Function                 | Description
 *zbc_report_nr_zones()*  | Get the number of zones of the device
 *zbc_report_zones()* <br> *zbc_list_zones()* | Get zone information
 *zbc_zone_operation()*   | Execute a zone operation
-*zbc_open_zone()*        | Explicitely open a zone
+*zbc_open_zone()*        | Explicitly open a zone
 *zbc_close_zone()*       | Close an open zone
 *zbc_finish_zone()*      | Finish a zone
 *zbc_reset_zone()*       | Reset a zone write pointer
@@ -336,7 +336,7 @@ $ doxygen libzbc.doxygen
 ## Tools
 
 Under the tools directory, several simple applications are available as
-examples. These appliations are as follows.
+examples. These applications are as follows.
 
 * **zbc_info** This application tests if a device file points to a physical
   zoned device supporting ZBC or ZAC features. This excludes the emulation mode

--- a/lib/zbc.h
+++ b/lib/zbc.h
@@ -138,7 +138,7 @@ struct zbc_device {
 	unsigned int		zbd_drv_flags;
 
 	/**
-	 * Report zone buffer size alignement.
+	 * Report zone buffer size alignment.
 	 */
 	size_t			zbd_report_bufsz_mask;
 

--- a/lib/zbc_ata.c
+++ b/lib/zbc_ata.c
@@ -148,7 +148,7 @@ static int zbc_ata_read_log(struct zbc_device *dev, uint8_t log,
 	struct zbc_sg_cmd cmd;
 	int ret;
 
-	/* Intialize command */
+	/* Initialize command */
 	ret = zbc_sg_cmd_init(dev, &cmd, ZBC_SG_ATA16, buf, bufsz);
 	if (ret != 0)
 		return ret;
@@ -222,7 +222,7 @@ static int zbc_ata_set_features(struct zbc_device *dev, uint8_t feature,
 	struct zbc_sg_cmd cmd;
 	int ret;
 
-	/* Intialize command */
+	/* Initialize command */
 	ret = zbc_sg_cmd_init(dev, &cmd, ZBC_SG_ATA16, NULL, 0);
 	if (ret != 0)
 		return ret;

--- a/lib/zbc_fake.c
+++ b/lib/zbc_fake.c
@@ -79,7 +79,7 @@ struct zbc_fake_meta {
 	uint32_t	zbd_nr_exp_open_zones;
 
 	/**
-	 * Number of implicitely open zones.
+	 * Number of implicitly open zones.
 	 */
 	uint32_t	zbd_nr_imp_open_zones;
 

--- a/lib/zbc_scsi.c
+++ b/lib/zbc_scsi.c
@@ -57,7 +57,7 @@ static int zbc_scsi_inquiry(struct zbc_device *dev,
 	struct zbc_sg_cmd cmd;
 	int ret;
 
-	/* Allocate and intialize inquiry command */
+	/* Allocate and initialize inquiry command */
 	memset(buf, 0, buf_len);
 	ret = zbc_sg_cmd_init(dev, &cmd, ZBC_SG_INQUIRY, buf, buf_len);
 	if (ret != 0)
@@ -85,7 +85,7 @@ static int zbc_scsi_vpd_inquiry(struct zbc_device *dev,
 	struct zbc_sg_cmd cmd;
 	int ret;
 
-	/* Allocate and intialize inquiry command */
+	/* Allocate and initialize inquiry command */
 	memset(buf, 0, buf_len);
 	ret = zbc_sg_cmd_init(dev, &cmd, ZBC_SG_INQUIRY, buf, buf_len);
 	if (ret != 0)
@@ -324,7 +324,7 @@ static int zbc_scsi_do_report_zones(struct zbc_device *dev, uint64_t sector,
 	struct zbc_sg_cmd cmd;
 	int ret;
 
-	/* Intialize report zones command */
+	/* Initialize report zones command */
 	ret = zbc_sg_cmd_init(dev, &cmd, ZBC_SG_REPORT_ZONES, buf, bufsz);
 	if (ret != 0)
 		return ret;
@@ -853,7 +853,7 @@ static int zbc_scsi_open(const char *filename,
 		goto out;
 	}
 
-	/* Set device decriptor */
+	/* Set device descriptor */
 	ret = -ENOMEM;
 	dev = calloc(1, sizeof(struct zbc_device));
 	if (!dev)

--- a/lib/zbc_sg.c
+++ b/lib/zbc_sg.c
@@ -412,7 +412,7 @@ int zbc_sg_cmd_exec(struct zbc_device *dev, struct zbc_sg_cmd *cmd)
 	if (cmd->io_hdr.resid)
 		cmd->bufsz -= cmd->io_hdr.resid;
 
-	zbc_debug("%s: %s%s executed in %u ms, %zu B transfered "
+	zbc_debug("%s: %s%s executed in %u ms, %zu B transferred "
 		  "(%d B residual)\n\n",
 		  dev->zbd_filename,
 		  zbc_sg_cmd_name(cmd),
@@ -528,7 +528,7 @@ int zbc_sg_test_unit_ready(struct zbc_device *dev)
 
 		retries--;
 
-		/* Intialize command */
+		/* Initialize command */
 		zbc_sg_cmd_init(dev, &cmd, ZBC_SG_TEST_UNIT_READY, NULL, 0);
 		cmd.cdb[0] = ZBC_SG_TEST_UNIT_READY_CDB_OPCODE;
 


### PR DESCRIPTION
Fixes minor typos found in `lib/` and `README.md`